### PR TITLE
fix: fix ut-dtkaccounts compile error

### DIFF
--- a/dtkaccounts/tests/CMakeLists.txt
+++ b/dtkaccounts/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
     -lpthread
     -lgcov
     -lgtest
+    -lcrypt
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
fix ut-dtkaccounts compile error on deepin v20.7 kernel 5.15.45

Log: