### PR TITLE
fix: qch generate error

### DIFF
--- a/docs/accounts/index.zh_CN.md
+++ b/docs/accounts/index.zh_CN.md
@@ -1,5 +1,8 @@
 @page dtkaccounts dtkaccounts
 @brief dtk用户管理模块
+
+# dtkaccounts
+
 ## 项目介绍
 
 dtkaccounts是对于deepin/UOS系统上的org.freedesktop.Accounts的dbus接口和com.deepin.daemon.Accounts的dbus接口的封装，同时使用Qt以及Linux原生接口实现了一部分功能，其目的是在于方便第三方开发者轻松且快速的调用接口进行开发。<br>

--- a/docs/login/index.zh_CN.md
+++ b/docs/login/index.zh_CN.md
@@ -1,6 +1,8 @@
 @page dtklogin dtklogin
 @brief dtk登录管理模块
 
+# dtklogin
+
 ## 项目介绍
 
 dtklogin是对systemd-logind的DBus接口和dde-daemon提供的相关接口的封装。用于观察和管理用户 login 以及 seat 的状态。<br>

--- a/docs/power/index.zh_CN.md
+++ b/docs/power/index.zh_CN.md
@@ -1,7 +1,9 @@
 @page dtkpower dtkpower
 @brief dtk电源管理模块
 
-# 项目介绍
+# dtkpower
+
+## 项目介绍
 
 dtkpower是对于deepin/UOS系统上的upowerdbus接口和dde-daemon接口的封装，其目的是在于方便第三方开发者轻松且快速的调用接口进行开发。<br>
 @ref group_power "接口文档"

--- a/docs/rfmanager/index.zh_CN.md
+++ b/docs/rfmanager/index.zh_CN.md
@@ -1,6 +1,8 @@
 @page dtkrfmanager dtkrfmanager
 @brief dtk无线设备管理模块
 
+# dtkrfmanager
+
 ## 项目介绍
 
 `dtkrfmanager` 是对于 `deepin/UOS` 系统上的 rfkill 的封装，其目的是在于方便第三方开发者轻松且快速的调用接口管理无线设备。<br>

--- a/docs/systemtime/index.zh_CN.md
+++ b/docs/systemtime/index.zh_CN.md
@@ -1,10 +1,13 @@
 @page dtksystemtime dtksystemtime
 @brief dtk时间同步管理模块
 
+# dtksystemtime
+
 ## 项目介绍
 
 `dtksystemtime` 是对于 `deepin/UOS` 系统上关于时间同步相关接口的封装<br>
 @ref group_dtksystemtime "接口文档"
+
 ## 项目结构
 
 对外暴露出 `dsystemtime.h` 这个头文件


### PR DESCRIPTION
Qch file doesn't generate because index.md has wrong syntax. Standardize the syntax of all index markdowns.

Log: fix qch generate error