### PR TITLE
fix(accounts): guard userList against unavailable Accounts service

### DIFF
--- a/src/accounts/daccountsmanager.cpp
+++ b/src/accounts/daccountsmanager.cpp
@@ -7,6 +7,7 @@
 #include "daccountsmanager_p.h"
 #include "daccountsuser.h"
 
+#include <QDBusError>
 #include <QDebug>
 
 #include <grp.h>
@@ -48,15 +49,27 @@ DAccountsManager::~DAccountsManager() { }
 DExpected<QList<quint64>> DAccountsManager::userList() const
 {
     Q_D(const DAccountsManager);
+    if (!d->m_dAccountsInter->isServiceRegistered()) {
+        return DUnexpected{ DCORE_NAMESPACE::emplace_tag::USE_EMPLACE,
+                            static_cast<int>(QDBusError::ServiceUnknown),
+                            QStringLiteral("Accounts service not available") };
+    }
     QList<quint64> list;
     auto reply = d->m_dAccountsInter->listCachedUsers();
     reply.waitForFinished();
-    if (!reply.isValid()) {
+    if (reply.isError() || !reply.isValid()) {
         return DUnexpected{ DCORE_NAMESPACE::emplace_tag::USE_EMPLACE,
                             reply.error().type(),
                             reply.error().message() };
     }
-    for (const auto &user : reply.value()) {
+    const auto value = reply.value();
+    for (int i = 0; i < value.size(); ++i) {
+        const auto &user = value.at(i);
+        if (user.path().isEmpty()) {
+            qWarning() << "DAccountsManager::userList: empty QDBusObjectPath at index" << i
+                       << "of" << value.size() << "skipped — accounts-daemon returned invalid entry";
+            continue;
+        }
         list.append(d->getUIDFromObjectPath(user.path()));
     }
     return list;

--- a/src/accounts/dbus/daccountsinterface.cpp
+++ b/src/accounts/dbus/daccountsinterface.cpp
@@ -5,6 +5,8 @@
 #include "daccountsinterface.h"
 
 #include <QDBusConnection>
+#include <QDBusConnectionInterface>
+#include <QDBusReply>
 
 DACCOUNTS_BEGIN_NAMESPACE
 
@@ -40,6 +42,20 @@ DAccountsInterface::DAccountsInterface(QObject *parent)
 QString DAccountsInterface::daemonVersion() const
 {
     return qdbus_cast<QString>(m_inter->property("DaemonVersion"));
+}
+
+bool DAccountsInterface::isServiceRegistered() const
+{
+    // DDBusInterface::serviceValid() is filled in by an async NameHasOwner
+    // callback. Callers such as Treeland's UserModel invoke userList() before
+    // QCoreApplication::exec(), so serviceValid() is still false even when the
+    // service is up. Query the same connection/service synchronously so this
+    // also respects USE_FAKE_INTERFACE (sessionBus / FakeAccounts).
+    QDBusConnectionInterface *iface = m_inter->connection().interface();
+    if (!iface)
+        return false;
+    const QDBusReply<bool> reply = iface->isServiceRegistered(m_inter->service());
+    return reply.isValid() && reply.value();
 }
 
 QDBusPendingReply<QDBusObjectPath> DAccountsInterface::cacheUser(const QString &name)

--- a/src/accounts/dbus/daccountsinterface.h
+++ b/src/accounts/dbus/daccountsinterface.h
@@ -24,6 +24,8 @@ public:
     Q_PROPERTY(QString daemonVersion READ daemonVersion)
     QString daemonVersion() const;
 
+    bool isServiceRegistered() const;
+
 public Q_SLOTS:
     QDBusPendingReply<QDBusObjectPath> cacheUser(const QString &name);
     QDBusPendingReply<QDBusObjectPath> createUser(const QString &name,


### PR DESCRIPTION
### Problem

`DAccountsManager::userList()` 在 `org.freedesktop.Accounts` 不可用时直接解引用空 `QArrayDataPointer<QDBusObjectPath>`（`needsDetach(this=0x0)`），导致 `SIGSEGV`（exit 139）。`gdb` 栈：

```
#0 QArrayDataPointer<QDBusObjectPath>::needsDetach(this=0x0)
#1 QMovableArrayOps<QDBusObjectPath>::emplace
#2 DAccountsManager::userList() at daccountsmanager.cpp:52
#3 UserModel::UserModel at treeland/src/greeter/usermodel.cpp:64
#4 Helper::init -> QQmlEngine::singletonInstance<UserModel>
```

在 `treeland` 启动时必现：`Helper::init` 无条件实例化 `UserModel` QML 单例，`dde-system-daemon`（`org.deepin.dde.Accounts1`）因 Go `concurrent map` 竞态崩溃后，`org.freedesktop.Accounts` 虽在但 `QDBusPendingReply::value()` 的解包路径在部分传输下返回 `QDBusArgument` 而非 `QList<QDBusObjectPath>`，原有 `!isValid` 检查不足，遍历空指针列表触发崩溃。

`dtk6systemsettings` 会自动从本仓库同步，故修复提交至此。

### Fix

* 调用前 `QDBusConnection::systemBus().interface()->isServiceRegistered("org.freedesktop.Accounts")`，不可用时直接返回 `DUnexpected{ServiceUnknown}`
* `waitForFinished` 后同时检查 `isError() || !isValid()`
* `const auto value = reply.value()` 拷贝后遍历，跳过空 `path()`

已在 `archlinux` + `accounts-daemon 788` + `treeland` 验证：原库必 `SIGSEGV`，补丁库后正常启动。

Log: fix accounts userList SIGSEGV when service unavailable

## Summary by Sourcery

Guard account user enumeration against unavailable services and malformed D-Bus responses.

Bug Fixes:
- Prevent crashes in user listing when the Accounts service is unavailable or returns invalid user object paths.
- Return an appropriate D-Bus service-unavailable error when the Accounts service cannot be reached.

Enhancements:
- Expose Accounts service availability through the D-Bus interface and validate pending replies before processing users.